### PR TITLE
Parameterizing the number of threads in Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Assuming you have the shift-reduce parser's model in a directory called `$NLPToo
 java -cp $NLPTools/stanford-parser/stanford-srparser-2014-10-23-models.jar:target/stanford-sr-parser-zeromq-server-0.0.3-SNAPSHOT.jar org.ets.research.nlp.corenlp.zeromq.Server tcp://$(hostname):5555
 ```
 
-If you could like to specify the number of threads (default: 10), you can do so as follows:
+If you would like to specify the number of threads (default: 10), you can do so as follows:
 
 ```
 java -cp $NLPTools/stanford-parser/stanford-srparser-2014-10-23-models.jar:target/stanford-sr-parser-zeromq-server-0.0.3-SNAPSHOT.jar org.ets.research.nlp.corenlp.zeromq.Server tcp://$(hostname):5555 10

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Assuming you have the shift-reduce parser's model in a directory called `$NLPToo
 java -cp $NLPTools/stanford-parser/stanford-srparser-2014-10-23-models.jar:target/stanford-sr-parser-zeromq-server-0.0.3-SNAPSHOT.jar org.ets.research.nlp.corenlp.zeromq.Server tcp://$(hostname):5555
 ```
 
+If you could like to specify the number of threads (default: 10), you can do so as follows:
+
+```
+java -cp $NLPTools/stanford-parser/stanford-srparser-2014-10-23-models.jar:target/stanford-sr-parser-zeromq-server-0.0.3-SNAPSHOT.jar org.ets.research.nlp.corenlp.zeromq.Server tcp://$(hostname):5555 10
+```
+
 All other JARs needed are contained within the stanford-sr-parser-zeromq-server JAR.
 
 Build with Maven with:

--- a/src/org/ets/research/nlp/corenlp/zeromq/Server.java
+++ b/src/org/ets/research/nlp/corenlp/zeromq/Server.java
@@ -63,7 +63,7 @@ public class Server
         {
                 
             // get the number of threads as an integer
-            threads = Integer.parseInt(args[1]);
+            int threads = Integer.parseInt(args[1].trim());
 
             @SuppressWarnings("unused")
             Server server = new Server(args[0], threads);

--- a/src/org/ets/research/nlp/corenlp/zeromq/Server.java
+++ b/src/org/ets/research/nlp/corenlp/zeromq/Server.java
@@ -9,12 +9,13 @@ import edu.stanford.nlp.tagger.maxent.MaxentTagger;
 
 public class Server
 {
-    private final int THREADS = 10;
+
     private ShiftReduceParser srModel;
     private MaxentTagger tagger;
 
-    public Server(String myBrokerAddress)
+    public Server(String myBrokerAddress, int threads)
     {
+
         try
         {
             System.err.println("Initializing MaxentTagger...");
@@ -31,7 +32,7 @@ public class Server
             Socket workers = context.socket(ZMQ.DEALER);
             workers.bind("inproc://workers");
 
-            for (int thread_nbr = 0; thread_nbr < this.THREADS; thread_nbr++)
+            for (int thread_nbr = 0; thread_nbr < threads; thread_nbr++)
             {
                 System.err.println("Starting worker thread " + thread_nbr);
                 Thread worker = new Worker(context, srModel, tagger);
@@ -48,12 +49,25 @@ public class Server
         }
     }
 
+    public Server(String myBrokerAddress)
+    {
+        this(myBrokerAddress, 10)
+    }
+
     public static void main(String[] args)
     {
-        // org.ets.research.nlp.corenlp.zeromq.Server <broker address>
+        // org.ets.research.nlp.corenlp.zeromq.Server <broker address> [thread count]
         // for example:
         // tcp://127.0.0.1:5555
-        @SuppressWarnings("unused")
-        Server server = new Server(args[0]);
+        if (args.length == 2)
+        {
+            @SuppressWarnings("unused")
+            Server server = new Server(args[0], args[1]);
+        }
+        else
+        {
+            @SuppressWarnings("unused")
+            Server server = new Server(args[0]);
+        }
     }
 }

--- a/src/org/ets/research/nlp/corenlp/zeromq/Server.java
+++ b/src/org/ets/research/nlp/corenlp/zeromq/Server.java
@@ -51,7 +51,7 @@ public class Server
 
     public Server(String myBrokerAddress)
     {
-        this(myBrokerAddress, 10)
+        this(myBrokerAddress, 10);
     }
 
     public static void main(String[] args)

--- a/src/org/ets/research/nlp/corenlp/zeromq/Server.java
+++ b/src/org/ets/research/nlp/corenlp/zeromq/Server.java
@@ -61,8 +61,12 @@ public class Server
         // tcp://127.0.0.1:5555
         if (args.length == 2)
         {
+                
+            // get the number of threads as an integer
+            threads = Integer.parseInt(args[1]);
+
             @SuppressWarnings("unused")
-            Server server = new Server(args[0], args[1]);
+            Server server = new Server(args[0], threads);
         }
         else
         {


### PR DESCRIPTION
This is a simple PR to parameterize the number of threads in `Server`. By default, this will be `10`. 

I haven't tested this yet.
